### PR TITLE
Add -ff option to git clean

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -287,6 +287,7 @@ module Git
     # options:
     #  :force
     #  :d
+    #  :ff
     #
     def clean(opts = {})
       self.lib.clean(opts)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -682,6 +682,7 @@ module Git
     def clean(opts = {})
       arr_opts = []
       arr_opts << '--force' if opts[:force]
+      arr_opts << '-ff' if opts[:ff]
       arr_opts << '-d' if opts[:d]
       arr_opts << '-x' if opts[:x]
 

--- a/tests/units/test_index_ops.rb
+++ b/tests/units/test_index_ops.rb
@@ -49,6 +49,11 @@ class TestIndexOps < Test::Unit::TestCase
         g.add
         g.commit("first commit")
 
+        FileUtils.mkdir_p("nested")
+        Dir.chdir('nested') do
+          Git.init
+        end
+
         new_file('file-to-clean', 'blablahbla')
         FileUtils.mkdir_p("dir_to_clean")
 
@@ -76,6 +81,11 @@ class TestIndexOps < Test::Unit::TestCase
 
         g.clean(:force => true, :x => true)
         assert(!File.exist?('ignored_file'))
+
+        assert(File.exist?('nested'))
+
+        g.clean(:ff => true, :d => true)
+        assert(!File.exist?('nested'))
       end
     end
   end


### PR DESCRIPTION
Git will refuse to modify untracked nested git repositories
(directories with a .git subdirectory) unless a second -f is given.

This adds the ability to pass "-ff" to git clean to enable removing
directories with a .git subdirectory.

An example use case is when a gem from a git source is cached in
vendor/cache/some_gem
Removing this with "git clean" would require "git clean -dff"
